### PR TITLE
Reduser antall CI-jobber som kjører

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,9 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
-          - {os: macOS-latest, r: 'release'}
-          - {os: ubuntu-22.04, r: 'release'}
           - {os: ubuntu-24.04, r: 'release'}
 
     env:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -5,11 +5,9 @@ on:
     types: [published]
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Kun kjør på ubuntu 24.04, og dropp snyk på PR

Closes #8